### PR TITLE
feat: write log entry in case of successfull send/rcv or timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ Receives NAT test messages from the
 [NAT Test Firmware](https://github.com/NordicSemiconductor/NAT-TestFirmware/)
 and logs them and timeout occurances to S3.
 
+## NAT Timeout determination
+
+The server listens for TCP and UPD connections. Clients can send messages
+according to the [`schema.json`](./schema.json) which contain an `interval`
+property. This instructs the server to wait that amount in seconds before
+returning a response.
+
+On _TCP connections_ the connection is considered to be timed out when the
+server cannot reply to the client after the interval has passed. The TCP
+connection will ensure that the client receives the message from the server if
+it is still connected.
+
+On _UDP connections_ the connection is considered to be timed out when the
+server does not receive a new message from the client within 60 seconds after
+having sent the response for the previous message. There is no other way to
+ensure that the connection is intact.
+
 ## Testing
 
 Make these environment variable available:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To test if the server is listening on local ports and saves the correct data,
 execute the command
 
 ```
+go get -v -t -d ./...
 go test
 ```
 

--- a/server_test.go
+++ b/server_test.go
@@ -123,7 +123,7 @@ func TCPFunc(t *testing.T) {
 			conn.Close()
 			t.Error("Error reading connection")
 			return
-		} else if bytes.Compare(tempBuf[:n], dcBuffer) == 0 {
+		} else if bytes.Compare(tempBuf[:n], genericErrorMessage) == 0 {
 			conn.Close()
 			t.Errorf("Wrong format in packet: %s\n", v)
 			return
@@ -188,7 +188,7 @@ func UDPFunc(t *testing.T) {
 			conn.Close()
 			t.Error("Error reading connection")
 			return
-		} else if bytes.Compare(tempBuf[:n], dcBuffer) == 0 {
+		} else if bytes.Compare(tempBuf[:n], genericErrorMessage) == 0 {
 			conn.Close()
 			t.Errorf("Wrong format in packet: %s\n", v)
 			return
@@ -208,7 +208,7 @@ func TestHandleData(t *testing.T) {
 
 func TestOutput(t *testing.T) {
 	// Wait for timeout + 10% for timeout packets to be written
-	time.Sleep(time.Duration(newPacketTimeout*1.1) * time.Second)
+	time.Sleep(time.Duration(newUDPMessageTimeoutInSeconds*1.1) * time.Second)
 
 	sess, err := session.NewSession(&aws.Config{})
 	if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -86,15 +85,13 @@ func TestTCP(t *testing.T) {
 }
 
 func TCPFunc(t *testing.T) {
+	assert := assert.New(t)
 	t.Parallel()
 
 	doneChan := make(chan bool)
 
 	conn, err := net.Dial("tcp", ":3051")
-	if err != nil {
-		t.Error("could not connect to server: ", err)
-		return
-	}
+	assert.NoError(err, "It should be able to connect to the server")
 	defer conn.Close()
 
 	for _, v := range testCases {
@@ -118,15 +115,8 @@ func TCPFunc(t *testing.T) {
 
 		tempBuf := make([]byte, 256)
 		n, err := conn.Read(tempBuf)
-		if err != nil {
-			conn.Close()
-			t.Error("Error reading connection")
-			return
-		} else if bytes.Compare(tempBuf[:n], genericErrorMessage) == 0 {
-			conn.Close()
-			t.Errorf("Wrong format in packet: %s\n", v)
-			return
-		}
+		assert.NoError(err, "It should read the response")
+		assert.NotEqual(tempBuf[:n], genericErrorMessage, "it should return an error message")
 		doneChan <- true
 	}
 }
@@ -138,28 +128,15 @@ func TestUDP(t *testing.T) {
 }
 
 func UDPFunc(t *testing.T) {
+	assert := assert.New(t)
 	t.Parallel()
 
 	doneChan := make(chan bool)
 
-	ServerAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:3050")
-	if err != nil {
-		t.Error("Error resolving remote address")
-		return
-	}
-
-	LocalAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Error("Error resolving local address")
-		return
-	}
-
+	ServerAddr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:3050")
+	LocalAddr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:0")
 	conn, err := net.DialUDP("udp", LocalAddr, ServerAddr)
-	if err != nil {
-		t.Error("Error connecting to server")
-		return
-	}
-
+	assert.NoError(err, "It should be able to connect to the server")
 	defer conn.Close()
 
 	for _, v := range testCases {
@@ -183,60 +160,44 @@ func UDPFunc(t *testing.T) {
 
 		tempBuf := make([]byte, 256)
 		n, err := conn.Read(tempBuf)
-		if err != nil {
-			conn.Close()
-			t.Error("Error reading connection")
-			return
-		} else if bytes.Compare(tempBuf[:n], genericErrorMessage) == 0 {
-			conn.Close()
-			t.Errorf("Wrong format in packet: %s\n", v)
-			return
-		}
+		assert.NoError(err, "It should read the response")
+		assert.NotEqual(tempBuf[:n], genericErrorMessage, "it should return an error message")
 		doneChan <- true
 	}
 }
 
 func TestHandleData(t *testing.T) {
+	assert := assert.New(t)
 	for _, errorCase := range errorCases {
 		_, _, err := HandleData(errorCase, "UDP", testIPv4)
-		if err == nil {
-			t.Errorf("Wrong format was accepted by server. Sent: %s\n", errorCase)
-		}
+		assert.Error(err, "An invalid message should not be accepted by the server: %s", errorCase)
 	}
 }
 
 func TestOutput(t *testing.T) {
+	assert := assert.New(t)
 	// Wait for timeout + 10% for timeout packets to be written
 	time.Sleep(time.Duration(newUDPMessageTimeoutInSeconds*1.1) * time.Second)
 
 	sess, err := session.NewSession(&aws.Config{})
-	if err != nil {
-		log.Fatal("Error creating session ", err)
-	}
+	assert.NoError(err, "A session should be created")
 	svc := s3.New(sess, &aws.Config{})
 
 	resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: aws.String(os.Getenv("AWS_BUCKET")), Prefix: aws.String(testPrefix)})
-	if err != nil {
-		t.Error("Unable to get bucket items", err)
-	}
+	assert.NoError(err, "Items in the bucket should be listed")
 
 	var foundCount = 0
 	var timedOutCount = 0
 	for _, item := range resp.Contents {
 		obj, err := svc.GetObject(&s3.GetObjectInput{Bucket: aws.String(os.Getenv("AWS_BUCKET")), Key: aws.String(*item.Key)})
-		if err != nil {
-			t.Error("Unable to read bucket item", err)
-		}
+		assert.NoError(err, "The item should be read")
 		body, err := ioutil.ReadAll(obj.Body)
-		if err != nil {
-			t.Error("Failed to read body of file")
-		}
+		assert.NoError(err, "The item's body should be read")
 
 		var log NATLogEntry
 		err = json.Unmarshal(body, &log)
-		if err != nil {
-			t.Error("Failed to read json data")
-		} else if log.Message.IP[0] == testIPv4 || log.Message.IP[0] == testIPv6 {
+		assert.NoError(err, "The item should be parsed to JSON")
+		if log.Message.IP[0] == testIPv4 || log.Message.IP[0] == testIPv6 {
 			foundCount++
 		}
 		if log.Timeout {
@@ -244,7 +205,6 @@ func TestOutput(t *testing.T) {
 		}
 	}
 
-	assert := assert.New(t)
 	assert.Equal(threadCount*2*len(testCases), foundCount, "The number of log entries should be equal.")
 	// The TCP messages will not timeout because the server sends the response in sync, while for UDP it waits for the *next* message to arrive before registering a success/timeout.
 	// This message never arrives, because the test client is terminated after the last test case.


### PR DESCRIPTION
The purpose of this change is to have either a timeout: true or timeout: false log message per interval.

This includes some refactorings of the code
to make it more legible